### PR TITLE
Fixed namespace for make_unique in Examples

### DIFF
--- a/examples/RpgoReadG2o.cpp
+++ b/examples/RpgoReadG2o.cpp
@@ -26,7 +26,7 @@ void Simulate(gtsam::GraphAndValues gv,
   gtsam::NonlinearFactorGraph nfg = *gv.first;
   gtsam::Values values = *gv.second;
 
-  std::unique_ptr<RobustSolver> pgo = make_unique<RobustSolver>(params);
+  std::unique_ptr<RobustSolver> pgo = std::make_unique<RobustSolver>(params);
 
   size_t dim = getDim<T>();
 

--- a/examples/RpgoReadG2o.cpp
+++ b/examples/RpgoReadG2o.cpp
@@ -26,7 +26,7 @@ void Simulate(gtsam::GraphAndValues gv,
   gtsam::NonlinearFactorGraph nfg = *gv.first;
   gtsam::Values values = *gv.second;
 
-  std::unique_ptr<RobustSolver> pgo = std::make_unique<RobustSolver>(params);
+  std::unique_ptr<RobustSolver> pgo = RobustPGO::make_unique<RobustSolver>(params);
 
   size_t dim = getDim<T>();
 


### PR DESCRIPTION
The current master fails with:
error: call of overloaded ‘make_unique<RobustPGO::RobustSolver>(RobustPGO::RobustSolverParams&)’ is ambiguous
   std::unique_ptr<RobustSolver> pgo = make_unique<RobustSolver>(params);