### PR TITLE
Fix naming convention

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>KimeraRPGO</name>
+  <name>kimera_rpgo</name>
   <version>0.0.1</version>
   <description>KimeraRPGO</description>
 


### PR DESCRIPTION
The ROS community tries to follow common C variable naming conventions when assigning rosdep keys, as we package software using the same package name for consistency:  

* http://wiki.ros.org/ROS/Patterns/Conventions#Packages
* https://www.debian.org/doc/manuals/debmake-doc/ch05.en.html#name-version

I'd recommend keeping with lowercase + underscore to avoid future issues. 