### PR TITLE
remove hardcoded march=native flag (inherited from gtsam)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ target_link_libraries(KimeraRPGO
 
 target_compile_options(KimeraRPGO
   PRIVATE -Wall -pipe
-  PRIVATE -march=native
 )
 
 ###########################################################################


### PR DESCRIPTION
Hardcoding `-march=native` causes issues when gtsam is compiled with `GTSAM_BUILD_WITH_MARCH_NATIVE=OFF`, and gtsam exports the `-march=native` flag when necessary.