### PR TITLE
Fix/find gtsam unstable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(GTSAM REQUIRED)
 if (NOT GTSAM_FOUND)
   message(FATAL_ERROR "This program requires the GTSAM library.")
 endif(NOT GTSAM_FOUND)
+find_package(GTSAM_UNSTABLE QUIET)
 
 ###########################################################################
 # Find Boost

--- a/cmake/KimeraRPGOConfig.cmake.in
+++ b/cmake/KimeraRPGOConfig.cmake.in
@@ -11,6 +11,7 @@ if(NOT TARGET Boost::boost)
   INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
 endif()
 find_dependency(GTSAM REQUIRED)
+find_dependency(GTSAM_UNSTABLE QUIET)
 
 list(REMOVE_AT CMAKE_MODULE_PATH -1)
 

--- a/cmake/KimeraRPGOConfig.cmake.in
+++ b/cmake/KimeraRPGOConfig.cmake.in
@@ -11,7 +11,7 @@ if(NOT TARGET Boost::boost)
   INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
 endif()
 find_dependency(GTSAM REQUIRED)
-find_dependency(GTSAM_UNSTABLE QUIET)
+find_package(GTSAM_UNSTABLE QUIET)
 
 list(REMOVE_AT CMAKE_MODULE_PATH -1)
 


### PR DESCRIPTION
Fixes some issues with `gtsam_unstable` becoming a separate CMake package in recent GTSAM commits that should be relatively backwards compatible to older versions of GTSAM.