### PR TITLE
Fix/cmake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,27 +70,13 @@ configure_file(tests/test_config.h.in tests/test_config.h)
 
 ###########################################################################
 # Installation
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/KimeraRPGOConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY AnyNewerVersion
-)
-
-# Create KimeraRPGOConfig.cmake with extra info from KimeraRPGOConfig.cmake.in
-# This file is necessary to find_package the library KimeraRPGO.
-set(INSTALL_CONFIGDIR lib/cmake/KimeraRPGO)
-configure_package_config_file(
-  ${CMAKE_CURRENT_LIST_DIR}/cmake/KimeraRPGOConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/KimeraRPGOConfig.cmake
-  INSTALL_DESTINATION ${INSTALL_CONFIGDIR})
-
 include(GNUInstallDirs)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/KimeraRPGO)
+
 install(TARGETS KimeraRPGO
   EXPORT kimera-rpgo-export
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  INCLUDES DESTINATION include # We need this right?
-  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 install(EXPORT kimera-rpgo-export
   FILE
@@ -103,15 +89,23 @@ install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/
   DESTINATION include
   FILES_MATCHING PATTERN "*.h")
 
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/KimeraRPGOConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+# Create KimeraRPGOConfig.cmake with extra info from KimeraRPGOConfig.cmake.in
+# This file is necessary to find_package the library KimeraRPGO.
+configure_package_config_file(
+  ${CMAKE_CURRENT_LIST_DIR}/cmake/KimeraRPGOConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/KimeraRPGOConfig.cmake
+  INSTALL_DESTINATION ${INSTALL_CONFIGDIR})
 ## Install the config and configversion
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/KimeraRPGOConfig.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/KimeraRPGOConfigVersion.cmake
   DESTINATION ${INSTALL_CONFIGDIR}
 )
-
-export(TARGETS KimeraRPGO FILE KimeraRPGOTargets.cmake)
-export(PACKAGE KimeraRPGO)
 
 ################################################################################
 # Print configuration variables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ IF(APPLE)
 ENDIF()
 
 find_package(GTSAM REQUIRED)
-find_package(GTSAM_UNSTABLE QUIET)
 
 ###########################################################################
 # Compile
@@ -43,7 +42,6 @@ target_include_directories(KimeraRPGO PUBLIC
 target_link_libraries(KimeraRPGO
   PUBLIC
     gtsam
-    gtsam_unstable
   PRIVATE
     rpgo_max_clique
 )

--- a/cmake/KimeraRPGOConfig.cmake.in
+++ b/cmake/KimeraRPGOConfig.cmake.in
@@ -1,12 +1,10 @@
-get_filename_component(KimeraRPGO_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+@PACKAGE_INIT@
 include(CMakeFindDependencyMacro)
 
-list(APPEND CMAKE_MODULE_PATH ${KimeraRPGO_CMAKE_DIR})
+get_filename_component(KimeraRPGO_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 find_dependency(GTSAM REQUIRED)
-find_package(GTSAM_UNSTABLE QUIET)
-
-list(REMOVE_AT CMAKE_MODULE_PATH -1)
+find_dependency(GTSAM_UNSTABLE QUIET)
 
 if(NOT TARGET KimeraRPGO)
   include("${KimeraRPGO_CMAKE_DIR}/KimeraRPGOTargets.cmake")
@@ -20,4 +18,5 @@ else()
   set(KimeraRPGO_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include/KimeraRPGO" CACHE PATH "KimeraRPGO include directory")
 endif()
 
-SET(KimeraRPGO_INCLUDE_DIRS ${KimeraRPGO_INCLUDE_DIR})
+set(KimeraRPGO_LIBRARIES KimeraRPGO)
+check_required_components(KimeraRPGO)

--- a/cmake/KimeraRPGOConfig.cmake.in
+++ b/cmake/KimeraRPGOConfig.cmake.in
@@ -4,7 +4,6 @@ include(CMakeFindDependencyMacro)
 get_filename_component(KimeraRPGO_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 find_dependency(GTSAM REQUIRED)
-find_dependency(GTSAM_UNSTABLE QUIET)
 
 if(NOT TARGET KimeraRPGO)
   include("${KimeraRPGO_CMAKE_DIR}/KimeraRPGOTargets.cmake")

--- a/cmake/KimeraRPGOConfig.cmake.in
+++ b/cmake/KimeraRPGOConfig.cmake.in
@@ -9,13 +9,5 @@ if(NOT TARGET KimeraRPGO)
   include("${KimeraRPGO_CMAKE_DIR}/KimeraRPGOTargets.cmake")
 endif()
 
-if(EXISTS "${KimeraRPGO_CMAKE_DIR}/CMakeCache.txt")
-  # In build tree
-  set(KimeraRPGO_INCLUDE_DIR @CMAKE_SOURCE_DIR@ CACHE PATH "KimeraRPGO include directory")
-else()
-  # Find installed library
-  set(KimeraRPGO_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include/KimeraRPGO" CACHE PATH "KimeraRPGO include directory")
-endif()
-
 set(KimeraRPGO_LIBRARIES KimeraRPGO)
 check_required_components(KimeraRPGO)


### PR DESCRIPTION
@yunzc had to update some stuff because the install config file from kimera-rpgo was pointing to a non-existent include directory (and couldn't be exported as a dependency in catkin). Also took the opportunity to drop gtsam-unstable (which isn't used?) and clean up some minor cmake things a little