### PR TITLE
Fix build error in Ubuntu 20.04 

### DIFF
--- a/include/KimeraRPGO/outlier/Pcm.h
+++ b/include/KimeraRPGO/outlier/Pcm.h
@@ -69,7 +69,7 @@ class Pcm : public OutlierRemoval {
         odom_check_(true),
         loop_consistency_check_(true) {
     // check if templated value valid
-    BOOST_CONCEPT_ASSERT((gtsam::IsLieGroup<poseT>));
+    GTSAM_CONCEPT_ASSERT(gtsam::IsLieGroup<poseT>);
 
     if (params_.odom_threshold < 0 || params_.odom_rot_threshold < 0 ||
         params_.odom_trans_threshold < 0) {

--- a/include/KimeraRPGO/utils/GeometryUtils.h
+++ b/include/KimeraRPGO/utils/GeometryUtils.h
@@ -26,7 +26,7 @@ namespace KimeraRPGO {
 template <class T>
 static const size_t getRotationDim() {
   // get rotation dimension of some gtsam object
-  BOOST_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
+  GTSAM_CONCEPT_ASSERT(gtsam::IsLieGroup<T>);
   T sample_object;
   return sample_object.rotation().dimension;
 }
@@ -34,7 +34,7 @@ static const size_t getRotationDim() {
 template <class T>
 static const size_t getTranslationDim() {
   // get translation dimension of some gtsam object
-  BOOST_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
+  GTSAM_CONCEPT_ASSERT(gtsam::IsLieGroup<T>);
   T sample_object;
   return sample_object.translation().size();
 }
@@ -42,7 +42,7 @@ static const size_t getTranslationDim() {
 template <class T>
 static const size_t getDim() {
   // get overall dimension of some gtsam object
-  BOOST_CONCEPT_ASSERT((gtsam::IsLieGroup<T>));
+  GTSAM_CONCEPT_ASSERT(gtsam::IsLieGroup<T>);
   T sample_object;
   return sample_object.dimension;
 }


### PR DESCRIPTION
## Build error message: 

![image](https://github.com/user-attachments/assets/27b5ba8f-7e9a-432d-9902-275799c15696)

## Solution


In the context of #94 (the solution is also given here: [MIT-SPARK/Kimera-VIO-ROS#205](https://github.com/MIT-SPARK/Kimera-VIO-ROS/issues/205)), we conclude to change `BOOST_CONCEPT_ASSERT` with `GTSAM_CONCEPT_ASSERT` instead of adding redundant header files.

